### PR TITLE
PMS-1 : Create patient after deletion

### DIFF
--- a/pmsmodule/src/main/java/com/pms/pmsmodule/Controllers/PatientController.java
+++ b/pmsmodule/src/main/java/com/pms/pmsmodule/Controllers/PatientController.java
@@ -68,5 +68,4 @@ public class PatientController {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(new ApiResponse("Patient successfully deleted", LocalDateTime.now()));
     }
-
 }

--- a/pmsmodule/src/main/java/com/pms/pmsmodule/DTO/PatientRequestDT0.java
+++ b/pmsmodule/src/main/java/com/pms/pmsmodule/DTO/PatientRequestDT0.java
@@ -27,4 +27,6 @@ public class PatientRequestDT0 {
 
     @NotBlank(groups = CreatePatientValidationGroup.class, message = "Registered date is required")
     private String registeredDate;
+
+    private boolean deleted;
 }

--- a/pmsmodule/src/main/java/com/pms/pmsmodule/Mapper/PatientMapper.java
+++ b/pmsmodule/src/main/java/com/pms/pmsmodule/Mapper/PatientMapper.java
@@ -28,6 +28,7 @@ public class PatientMapper {
         patient.setEmail(patientRequestDT0.getEmail());
         patient.setDateOfBirth(LocalDate.parse(patientRequestDT0.getDateOfBirth()));
         patient.setRegisteredDate(LocalDate.parse(patientRequestDT0.getRegisteredDate()));
+        patient.setDeleted(false);
 
         return patient;
     }

--- a/pmsmodule/src/main/java/com/pms/pmsmodule/Repository/PatientRepository.java
+++ b/pmsmodule/src/main/java/com/pms/pmsmodule/Repository/PatientRepository.java
@@ -17,4 +17,7 @@ public interface PatientRepository extends JpaRepository<Patient, UUID> {
      * Create an optional since patient could be deleted
      */
     Optional<Patient> findByIdAndDeletedFalse(UUID id);
+    Optional<Patient> findByEmailAndDeletedTrue(String email);
+
+    boolean existsByEmailAndDeletedFalse(String email);
 }

--- a/pmsmodule/src/main/java/com/pms/pmsmodule/Services/PatientService.java
+++ b/pmsmodule/src/main/java/com/pms/pmsmodule/Services/PatientService.java
@@ -54,12 +54,34 @@ public class PatientService {
     }
     // Create a patient
     public PatientResponseDTO createPatient(PatientRequestDT0 patientRequestDT0){
-        if(patientRepository.existsByEmail(patientRequestDT0.getEmail())){
-            throw new EmailAlreadyExistsException("An patient with this email already exists"+patientRequestDT0);
-        }
-        Patient newPatient = patientRepository.save(PatientMapper.mapDTOtoModel(patientRequestDT0));
+        String email = patientRequestDT0.getEmail();
 
-        return PatientMapper.mapModelToDTO(newPatient);
+        // Check for active patients with the same email
+        if (patientRepository.existsByEmailAndDeletedFalse(email)) {
+            throw new EmailAlreadyExistsException("A patient with this email already exists");
+        }
+        // Check for a soft-deleted patient with the same email
+        Optional<Patient> softDeletedPatientOpt = patientRepository.findByEmailAndDeletedTrue(email);
+
+        if (softDeletedPatientOpt.isPresent()) {
+            Patient softDeletedPatient = softDeletedPatientOpt.get();
+
+            // Reactivate the patient and update values
+            softDeletedPatient.setDeleted(false);
+            softDeletedPatient.setName(patientRequestDT0.getName());
+            softDeletedPatient.setAddress(patientRequestDT0.getAddress());
+            softDeletedPatient.setDateOfBirth(LocalDate.parse(patientRequestDT0.getDateOfBirth()));
+            softDeletedPatient.setRegisteredDate(LocalDate.parse(patientRequestDT0.getRegisteredDate()));
+
+            Patient reactivatedPatient = patientRepository.save(softDeletedPatient);
+            return PatientMapper.mapModelToDTO(reactivatedPatient);
+        }
+
+        // Create new patient
+        Patient newPatient = PatientMapper.mapDTOtoModel(patientRequestDT0);
+        Patient savedPatient = patientRepository.save(newPatient);
+
+        return PatientMapper.mapModelToDTO(savedPatient);
     }
     //Update patient data
     public PatientResponseDTO updatePatientData(UUID patientId, PatientRequestDT0 patientData) {


### PR DESCRIPTION
**Link to Work Item on the Scrum Board**
https://kimenjudenis.atlassian.net/browse/PMS-1

**Root Cause Analysis**

- Once deleted(soft-deleted) with the flag 'deleted', they could not be updated since the `PatientService.updatePatientData method` throws an exception if the Patient is deleted.
- Also, a new Patient could not be posted since, the method checks if one exists. 
- 
**Class Diagram**

![patientService](https://github.com/user-attachments/assets/66d50423-d367-4d34-ad18-36811db6ea59)
![PatientService_3_createPatient_calls](https://github.com/user-attachments/assets/81bc5bee-62b9-41da-bb80-7d34206fdf2f)

**Sequence Diagram for the `createPatient` method**
![createPatient-SequenceDiagram](https://github.com/user-attachments/assets/e6b2327b-2d63-4922-8231-06ede3d1566e)

**Resolve**

- [x] 1. Check for active patients with the same email
- [x] Check for a soft-deleted patient with the same email
- [x] Reactivate the patient and update values on condition that the soft deleted patient is present
- [x] Otherwise, Create new patient