### PR TITLE
Adding dependencies and file structure

### DIFF
--- a/Billing-Service/pom.xml
+++ b/Billing-Service/pom.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>3.4.6</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+	<groupId>com.pms</groupId>
+	<artifactId>Billing-Service</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>Billing-Service</name>
+	<description>Billing-Service</description>
+	<url/>
+	<licenses>
+		<license/>
+	</licenses>
+	<developers>
+		<developer/>
+	</developers>
+	<scm>
+		<connection/>
+		<developerConnection/>
+		<tag/>
+		<url/>
+	</scm>
+	<properties>
+		<java.version>21</java.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-devtools</artifactId>
+			<scope>runtime</scope>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<!--GRPC Setup-->
+		<dependency>
+			<groupId>io.grpc</groupId>
+			<artifactId>grpc-netty-shaded</artifactId>
+			<version>1.69.0</version>
+		</dependency>
+		<dependency>
+			<groupId>io.grpc</groupId>
+			<artifactId>grpc-protobuf</artifactId>
+			<version>1.69.0</version>
+		</dependency>
+		<dependency>
+			<groupId>io.grpc</groupId>
+			<artifactId>grpc-stub</artifactId>
+			<version>1.69.0</version>
+		</dependency>
+		<dependency> <!-- necessary for Java 9+ -->
+			<groupId>org.apache.tomcat</groupId>
+			<artifactId>annotations-api</artifactId>
+			<version>6.0.53</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>net.devh</groupId>
+			<artifactId>grpc-spring-boot-starter</artifactId>
+			<version>3.1.0.RELEASE</version>
+		</dependency>
+		<dependency>
+			<groupId>com.google.protobuf</groupId>
+			<artifactId>protobuf-java</artifactId>
+			<version>4.29.1</version>
+		</dependency>
+
+	</dependencies>
+
+	<build>
+		<extensions>
+			<!-- Ensure OS compatibility for protoc -->
+			<extension>
+				<groupId>kr.motd.maven</groupId>
+				<artifactId>os-maven-plugin</artifactId>
+				<version>1.7.0</version>
+			</extension>
+		</extensions>
+		<plugins>
+			<!-- Spring boot / maven  -->
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+
+			<!-- PROTO -->
+			<plugin>
+				<groupId>org.xolstice.maven.plugins</groupId>
+				<artifactId>protobuf-maven-plugin</artifactId>
+				<version>0.6.1</version>
+				<configuration>
+					<protocArtifact>com.google.protobuf:protoc:3.25.5:exe:${os.detected.classifier}</protocArtifact>
+					<pluginId>grpc-java</pluginId>
+					<pluginArtifact>io.grpc:protoc-gen-grpc-java:1.68.1:exe:${os.detected.classifier}</pluginArtifact>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>compile</goal>
+							<goal>compile-custom</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<excludes>
+						<exclude>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</exclude>
+					</excludes>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+
+</project>

--- a/Billing-Service/src/main/java/com/pms/billingservice/BillingServiceApplication.java
+++ b/Billing-Service/src/main/java/com/pms/billingservice/BillingServiceApplication.java
@@ -1,0 +1,13 @@
+package com.pms.billingservice;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class BillingServiceApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(BillingServiceApplication.class, args);
+	}
+
+}

--- a/Billing-Service/src/main/resources/application.properties
+++ b/Billing-Service/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.application.name=Billing-Service

--- a/Billing-Service/src/test/java/com/pms/billingservice/BillingServiceApplicationTests.java
+++ b/Billing-Service/src/test/java/com/pms/billingservice/BillingServiceApplicationTests.java
@@ -1,0 +1,13 @@
+package com.pms.billingservice;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class BillingServiceApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}


### PR DESCRIPTION
Adding : File strcture and dependencies (refer to pom.xml)

`Plugins`	

- [x] `os-maven-plugin`

	Detects the operating system and architecture during Maven builds.
	Ensures platform-specific binaries (like protoc for Protocol Buffers) are downloaded and used correctly.

- [x] `spring-boot-maven-plugin`

	Builds and runs Spring Boot applications using Maven
	Used in all Spring Boot projects.
	Packages your app as an executable JAR or WAR.
	Provides commands like mvn spring-boot:run and mvn package	

- [x] `protobuf-maven-plugin`

	Generates Java source code from .proto files (Protocol Buffers) and gRPC service stubs
	Microservices using gRPC for communication.
	Automates code generation for message classes and gRPC service interfaces.
	Ensures compatibility and type safety between services.

- [x] `maven-compiler-plugin (with Lombok annotation processor)`

	Compiles Java code and processes annotations (like those from Lombok).
	Lombok reduces boilerplate code (getters, setters, constructors).
	The annotation processor ensures Lombok annotations are handled during compilation.

		> protobuf-maven-plugin and os-maven-plugin are critical for gRPC-based service-to-service communication.
		> spring-boot-maven-plugin is essential for packaging and running each microservice.
		> lombok and the compiler plugin help keep code concise and maintainable.
`Dependencies`

- [x] grpc-protobuf

	Purpose:
	Contains code to serialize and deserialize Protocol Buffers messages for gRPC.
	Where used:

	Used whenever you define .proto files and want to generate Java classes for gRPC communication.
		

- [x] grpc-stub

	Purpose:
	Provides the client and server stubs for gRPC services.
	Where used:

	Enables you to call remote gRPC services from Java code (client stubs).
	Used by the server to implement service interfaces.
		

- [x] annotations-api (for Java 9+)

	Purpose:
	Provides Java EE annotations (like @PostConstruct, @Resource) for compatibility with Java 9+ modules.
	Where used:

	Needed if your code or dependencies use Java EE annotations and you’re running on Java 9 or newer


- [x] grpc-spring-boot-starter

	Purpose:
	Integrates gRPC with Spring Boot, providing auto-configuration, service registration, and easier setup.
	Where used:

	Use this in Spring Boot microservices to expose or consume gRPC services with minimal configuration.
	

- [x] protobuf-java

	Purpose:
	Provides the core Protocol Buffers runtime for Java.
	Where used:

	Required for working with Protocol Buffers messages (serialization/deserialization).
	Used by both gRPC and any code that manipulates .proto-generated classes